### PR TITLE
Re-deploy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,27 +2,35 @@
 
 ## Prerequisites
 
-Install Python 3.6 and Pip and Pipenv.
+  + Python 3.6 or 3.7
+  + Pip
+  + Anaconda 3.7 (recommended)
 
 ## Installation
 
-Download source code:
+Download or clone the source code:
 
 ```sh
 git clone git@github.com:prof-rossetti/products-api-flask.git
+```
+
+Navigate into the repository from the command-line:
+
+```sh
 cd products-api-flask/
 ```
 
-Install package dependencies, including Flask:
+Create and activate a new virtual environment called something like "products-api-env", as necessary:
 
 ```sh
-pipenv install
+conda create -n products-api-env
+conda activate products-api-env
 ```
 
-All following commands assume you are running them from within a Pipenv virtual environment:
+Inside the virtual environment, install package dependencies, including Flask:
 
 ```sh
-pipenv shell
+pip install flask gunicorn python-dotenv
 ```
 
 ## Setup (CSV Version Only)
@@ -30,13 +38,13 @@ pipenv shell
 Before you run this application for the first time (and anytime you want to clear all records from the CSV file), reset the it:
 
 ```sh
-FLASK_ENV=development python3 products_api/reset.py
+FLASK_ENV=development python products_api/reset.py
 ```
 
 Optionally populate, or "seed", the file with the default records:
 
 ```sh
-FLASK_ENV=development python3 products_api/seed.py
+FLASK_ENV=development python products_api/seed.py
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Deployment Environments:
 
 branch | production_url | description
 --- | --- | ---
-[`master`](https://github.com/prof-rossetti/products-api-flask) | https://nyu-info-2335-products-api.herokuapp.com/ | A read-only version, using an in-memory datastore. Only supports the "List" and "Show" operations.
-[`csv`](https://github.com/prof-rossetti/products-api-flask/tree/csv) | https://nyu-info-2335-products-api-csv.herokuapp.com/ | A fully-functional version, using a CSV file datastore. Supports all operations.
+[`master`](https://github.com/prof-rossetti/products-api-flask) | https://____________________-products-api.herokuapp.com/ | A read-only version, using an in-memory datastore. Only supports the "List" and "Show" operations.
+[`csv`](https://github.com/prof-rossetti/products-api-flask/tree/csv) | https://____________________-products-api-csv.herokuapp.com/ | A fully-functional version, using a CSV file datastore. Supports all operations.
 
 
 ## API Documentation


### PR DESCRIPTION
Update documentation to reflect an anaconda-based approach.

Re-deploy to a server with a more generic URL, so this API can be used as an educational tool across organizations.